### PR TITLE
updateCommit now takes the current time, plus other changes

### DIFF
--- a/commands/the-path/commit.js
+++ b/commands/the-path/commit.js
@@ -21,7 +21,7 @@ module.exports = class Commit extends Command{
     let isThere = await db.findUser(message.author.id);
     if(isThere) return await message.direct('You already have a commitment.\nDid you mean to update it? Use `.update` to update your current commitment.\nYou can see your current commitments with the command `.commitments`.');
 
-    let res = await db.newCommit(message.author.id, text, new Date(), message.author.presence.status);
+    let res = await db.newCommit(message.author.id, text, message.author.presence.status);
     if(res === null) return await message.direct('There was an error trying to add the commitment. Let Alex or one of the bot master know!');
     return await message.direct(`${text} has been committed. Now use \`.remindme\` in #the-path to set the reminder.\nIf you need help, type \`.help <command>\` for more details.`);
   }

--- a/commands/the-path/update.js
+++ b/commands/the-path/update.js
@@ -21,7 +21,7 @@ module.exports = class Update extends Command {
     let isThere = await db.findUser(message.author.id);
     if(!isThere) return await message.direct('You have not created a commitment yet.\nUse `.commit` to add your first commitment!');
 
-    let res = await db.updateCommit(message.author.id, text);
+    let res = await db.updateCommit(message.author.id, text, new Date());
     if(res === null) return await message.direct('There was an error trying to update the commitment. Let Alex or one of the bot masters know!');
     return await message.direct(`Your commitment has been updated! Commitment changed from ${isThere.commit} to ${text}`);
   }

--- a/helpers.js
+++ b/helpers.js
@@ -2,18 +2,20 @@ const db = require('./db/db.js');
 const { DateTime } = require('luxon');
 
 
-checkTime = async (now, ocTime, dbInfo, user) => {
-  if(now.hour > ocTime.hour){
-    await this.sendReminder(user, dbInfo);
-  } else if(now.hour === ocTime.hour){
-    if(now.minute >= ocTime.minute){
-      await this.sendReminder(user, dbInfo);
+checkTime = async (now, dbInfo, client) => {
+  const rmTime = DateTime.fromJSDate(dbInfo.remindMeTime);
+  
+  if(now.hour > rmTime.hour){
+    await this.sendReminder(client, dbInfo);
+  } else if(now.hour === rmTime.hour){
+    if(now.minute >= rmTime.minute){
+      await this.sendReminder(client, dbInfo);
     }
   }
 }
 
-sendReminder = async (user, dbInfo) => {
-  const dm = await user.createDM();
+sendReminder = async (client, dbInfo) => {
+  const dm = await client.users.cache.get(dbInfor.userId).createDM();
 
   await dm.send(`Remember, your current commitment is:\n${dbInfo.commit}`);
   let res = await db.updateDMTime(user.id, new Date());
@@ -25,10 +27,9 @@ sendReminder = async (user, dbInfo) => {
 }
 
 module.exports = {
-  checkInterval: async (dbInfo, user) => {
+  checkInterval: async (dbInfo, client) => {
     const now = DateTime.now();
     const lastReminderTime = DateTime.fromJSDate(dbInfo.lastDMTime);
-    const ocTime = DateTime.fromJSDate(dbInfo.commitTime);
     const i = lastReminderTime.until(now);
 
     let IntervalOK = false;
@@ -41,7 +42,7 @@ module.exports = {
     }
 
     if(IntervalOK){
-      return await this.checkTime(now, ocTime, dbInfo, user);
+      return await this.checkTime(now, dbInfo, client);
     } return;
   },
 };

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ client.dispatcher.addInhibitor((message) => {
     if(isThere){
       if(typeof oldStatus === 'undefined' || oldStatus.status === 'offline'){
         await db.updateStatus(newStatus.userID, 'online');
-        if(isThere.remindMe !== 'never') await checkInterval(isThere, newStatus.user);
+        if(isThere.remindMe !== 'never') await checkInterval(isThere, client);
       } else if (newStatus.status === 'offline'){
         await db.updateStatus(newStatus.userID, newStatus.status);
       }
@@ -52,8 +52,7 @@ client.dispatcher.addInhibitor((message) => {
     const allCommits = await db.findAll();
     allCommits.forEach(async commitment => {
       if(commitment.remindMe !== 'never' && commitment.status === 'online')
-        let user = await client.users.cache.get(commitment.userId);
-        await checkInterval(commitment, user);
+        await checkInterval(commitment, client);
     });
   }, (1000 * 60));
 


### PR DESCRIPTION
main thing: updateCommit now takes the current time and stores that in the time field. Also removed time from newCommit, while storing null in where the time was used.
Other minor things: Renamed commitTime to remindMeTime. Change and move where some of the variables are created and used. Fix up styling, update comments and some typos