### PR TITLE
Changes from old bot configs

### DIFF
--- a/commands/the-path/commit.js
+++ b/commands/the-path/commit.js
@@ -25,10 +25,10 @@ module.exports = class Commit extends Command{
 
   async run(message, { text }){
     let isThere = await db.findUser(message.author.id);
-    if(isThere) return await message.say('You already have a commitment.\nDid you mean to update it? Use `.update` to update your current commitment.\nYou can see your current commitments with the command `.commitments`.');
+    if(isThere) return await message.reply('You already have a commitment.\nDid you mean to update it? Use `.update` to update your current commitment.\nYou can see your current commitments with the command `.commitments`.');
 
     let res = await db.newCommit(message.author.id, text, message.author.presence.status, new Date());
-    if(res === null) return await message.say('There was an error trying to add the commitment. Let Alex or one of the bot master know!');
-    return await message.say(`${text} has been committed. Now use \`.remindme\` in #the-path to set the reminder.\nIf you need help, type \`.help <command>\` for more details.`);
+    if(res === null) return await message.reply('There was an error trying to add the commitment. Let Alex or one of the bot master know!');
+    return await message.reply(`${text} has been committed. Now use \`.remindme\` in #the-path to set the reminder.\nIf you need help, type \`.help <command>\` for more details.`);
   }
 };

--- a/commands/the-path/commit.js
+++ b/commands/the-path/commit.js
@@ -15,14 +15,20 @@ module.exports = class Commit extends Command{
         type: 'string'
       }]
     });
+
+    this.responselist = [
+      'Noted! Now get after it! :getafterit:',
+      'Thanks, and good luck on The Path! :getafterit:',
+      'Commitments are the first step, stick to The Path! :getafterit:'
+    ]
   }
 
   async run(message, { text }){
     let isThere = await db.findUser(message.author.id);
-    if(isThere) return await message.direct('You already have a commitment.\nDid you mean to update it? Use `.update` to update your current commitment.\nYou can see your current commitments with the command `.commitments`.');
+    if(isThere) return await message.say('You already have a commitment.\nDid you mean to update it? Use `.update` to update your current commitment.\nYou can see your current commitments with the command `.commitments`.');
 
-    let res = await db.newCommit(message.author.id, text, message.author.presence.status);
-    if(res === null) return await message.direct('There was an error trying to add the commitment. Let Alex or one of the bot master know!');
-    return await message.direct(`${text} has been committed. Now use \`.remindme\` in #the-path to set the reminder.\nIf you need help, type \`.help <command>\` for more details.`);
+    let res = await db.newCommit(message.author.id, text, message.author.presence.status, new Date());
+    if(res === null) return await message.say('There was an error trying to add the commitment. Let Alex or one of the bot master know!');
+    return await message.say(`${text} has been committed. Now use \`.remindme\` in #the-path to set the reminder.\nIf you need help, type \`.help <command>\` for more details.`);
   }
 };

--- a/commands/the-path/remindme.js
+++ b/commands/the-path/remindme.js
@@ -15,7 +15,7 @@ module.exports = class RemindMe extends Command {
         key: 'frequency',
         prompt: 'How often do you want to be reminded?',
         type: 'string',
-        oneOf: ['never', 'daily', 'weekly', 'monthly'],
+        oneOf: ['never', 'daily', 'semiweekly', 'weekly', 'biweekly', 'monthly'],
       }]
     })
   }

--- a/commands/the-path/remindme.js
+++ b/commands/the-path/remindme.js
@@ -22,15 +22,15 @@ module.exports = class RemindMe extends Command {
 
   async run(message, { frequency }){
     let isThere = await db.findUser(message.author.id);
-    if(!isThere) return await message.direct('You have not created a commitment yet.\nUse `.commit` to add your first commitment!');
+    if(!isThere) return await message.reply('You have not created a commitment yet.\nUse `.commit` to add your first commitment!');
 
     if(frequency === isThere.remindMe) return await message.direct(`Your RemindMe is already set to ${frequency}. Did you mean to change it to one of the other options?`);
 
     let res = await db.updateRemindMe(message.author.id, frequency, new Date());
-    if(res === null) return await message.direct('There was an error trying to update the commitment. Let Alex or one of the bot masters know!');
+    if(res === null) return await message.reply('There was an error trying to update the commitment. Let Alex or one of the bot masters know!');
     const resMessage = ((frequency === 'never')
     ? `You will stop getting DM reminders. However, Meaningbot will still keep your commitments logged. Start is up again with \`.remindme\``
     : `You will get ${frequency} DM reminding you to get after it!`);
-    return await message.direct(resMessage);
+    return await message.reply(resMessage);
   }
 }

--- a/commands/the-path/update.js
+++ b/commands/the-path/update.js
@@ -15,14 +15,21 @@ module.exports = class Update extends Command {
         type: 'string'
       }]
     });
+
+    this.responselist = [
+      'Confront the Dragon, Get the Gold, Share it with the Community :jbp1:',
+      'Thanks for the update! :getafterit:',
+      'Get Some! :getafterit:',
+      'P R O U D   O F   Y O U :akira_happy'
+    ];
   }
 
   async run(message, { text }){
     let isThere = await db.findUser(message.author.id);
-    if(!isThere) return await message.direct('You have not created a commitment yet.\nUse `.commit` to add your first commitment!');
+    if(!isThere) return await message.reply('You have not created a commitment yet.\nUse `.commit` to add your first commitment!');
 
     let res = await db.updateCommit(message.author.id, text, new Date());
-    if(res === null) return await message.direct('There was an error trying to update the commitment. Let Alex or one of the bot masters know!');
-    return await message.direct(`Your commitment has been updated! Commitment changed from ${isThere.commit} to ${text}`);
+    if(res === null) return await message.reply('There was an error trying to update the commitment. Let Alex or one of the bot masters know!');
+    return await message.reply(`Your commitment has been updated! Commitment changed from ${isThere.commit} to ${text}`);
   }
 };

--- a/commands/the-path/viewcommitment.js
+++ b/commands/the-path/viewcommitment.js
@@ -1,7 +1,7 @@
 const { Command } = require('discord.js-commando');
 const db = require('../../db/db.js');
 
-module.exports = class viewcommitment extends Command{
+module.exports = class ViewCommitment extends Command{
   constructor(client){
     super(client, {
       name: 'viewcommitment',

--- a/commands/the-path/viewcommitment.js
+++ b/commands/the-path/viewcommitment.js
@@ -1,7 +1,7 @@
 const { Command } = require('discord.js-commando');
 const db = require('../../db/db.js');
 
-module.exports = class viewcommitments extends Command{
+module.exports = class viewcommitment extends Command{
   constructor(client){
     super(client, {
       name: 'viewcommitment',

--- a/commands/the-path/viewcommitment.js
+++ b/commands/the-path/viewcommitment.js
@@ -1,12 +1,12 @@
 const { Command } = require('discord.js-commando');
 const db = require('../../db/db.js');
 
-module.exports = class Commitments extends Command{
+module.exports = class viewcommitments extends Command{
   constructor(client){
     super(client, {
-      name: 'commitments',
+      name: 'viewcommitment',
       group: 'the-path',
-      memberName: 'commitments',
+      memberName: 'viewcommitment',
       description: 'Reads out your current commitments back to you.',
       example: ['`.commitments` Your current commitments are: ```Do 100 push-ups```',
                 '`.commitments` Your current commitments are: ```Clean up your room```',
@@ -16,8 +16,8 @@ module.exports = class Commitments extends Command{
 
   async run(message){
     let isThere = await db.findUser(message.author.id);
-    if(!isThere) return await message.direct('You have not created a commitment yet.\nUse `.commit` to add your first commitment!');
+    if(!isThere) return await message.reply('You have not created a commitment yet.\nUse `.commit` to add your first commitment!');
     
-    return await message.reply(`Your current commitment is: ${isThere.commit}`);
+    return await message.reply(`Your current commitment is:\n"${isThere.commit}"\nAnd you will get a DM reminder this often: ${isThere.remindMe}`);
   }
 }

--- a/db/db.js
+++ b/db/db.js
@@ -44,7 +44,7 @@ module.exports = {
     }
   },
   // Add a new commitment to the database.
-  newCommit: async function(id, commit, status) {
+  newCommit: async function(id, commit, status, time) {
     /** Param should be the following:
      *    userId: <user id, using their discord's unique id>
      *    commit: <commitment message>
@@ -56,9 +56,9 @@ module.exports = {
       return await col.insertOne({
         'userId': id,
         'commit': commit,
-        'remindMe': 'never',
-        'remindMeTime': null,
-        'lastDMTime': null,
+        'remindMe': 'semiweekly',
+        'remindMeTime': time,
+        'lastDMTime': time,
         'status': status });
     } catch (err){
       console.error(err);

--- a/helpers.js
+++ b/helpers.js
@@ -33,9 +33,13 @@ module.exports = {
     const i = lastReminderTime.until(now);
 
     let IntervalOK = false;
-    if(dbInfo.remindMe === 'daily' && i.length('days') >= 1){
+    if(dbInfo.remindMe === 'daily' && i.length('hours') >= 24){
+      IntervalOK = true;
+    } else if(db.dbInfo.remindMe === 'semiweekly' && i.length('days') >= 3){
       IntervalOK = true;
     } else if(dbInfo.remindMe === 'weekly' && i.length('days') >= 7){
+      IntervalOK = true;
+    } else if(dbInfo.remindMe === 'biweekly' && i.length('days') >= 14){
       IntervalOK = true;
     } else if(dbInfo.remindMe === 'monthly' && i.length('months') >= 1){
       IntervalOK = true;

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ client.dispatcher.addInhibitor((message) => {
   if(!(message.channel.type === 'dm' && message.command.name === 'help')){
     if(message.channel.id !== process.env.THE_PATH_CHANNEL_ID){
       return {reason: 'Wrong Channel',
-      response: message.reply('This is the wrong channel to use the commands. Please use the commands in <#848008771397353505>')};    
+      response: message.reply('I only take commands in <#848008771397353505> channel')};    
     }
   }
 });

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ The bot will take commands from #the-path channel. It will DM the user to remind
 
 ```
 .commit - set a commitment or goal to get after it
-.remindme [daily/weekly/monthly/never] - set the interval of how often the user is reminded to stay on the path
+.remindme [daily/semiweekly/weekly/biweekly/monthly/never] - set the interval of how often the user is reminded to stay on the path
 .update - update the bot (and the community) on the current progress
 .getsome - Bot will post a random message from The ＰＡＴＨ ＧＡＮＧ
 .commands - get a list of commands sent to your DM


### PR DESCRIPTION
Found old bot configs and added/match the features to better resemble the old bot.
1) RemindMe: Added back in "semiweekly" and "biweekly" as an option. Semiweekly = every 3 days. Biweekly = every 14 days.
2) Added response list to the commit and update commands. Will switch over to the response list shortly. This way to give the bot more of a personality.
3) Update small portion of getsome command's response list. Found the old bot's list of response. Will slowly integrate those back in, like commit and update's response list.
4) Rename commitments to viewcommitment. That was the old bot's command to view commitment, and it made more sense. 
5) Change some of the bot's response message to match what the old bot used to say or be similar to what the old bot used to say.
6) Change all the bot's response from DM to reply. This way the community knows the bot is running. Also keep the DM strictly to reminder message only.