### PR TITLE
Change command prefix and bot reminder DM logic

### DIFF
--- a/commands/the-path/commit.js
+++ b/commands/the-path/commit.js
@@ -8,7 +8,7 @@ module.exports = class Commit extends Command{
       group: 'the-path',
       memberName: 'commit',
       description: 'Set your first commitment log to start your journey down the path!',
-      example: ['`.commit Do 100 push-ups`', '`.commit Get after it everyday!`'],
+      example: ['`!commit Do 100 push-ups`', '`!commit Get after it everyday!`'],
       args: [{
         key: 'text',
         prompt: 'What are you commiting to?',

--- a/commands/the-path/getsome.js
+++ b/commands/the-path/getsome.js
@@ -7,7 +7,7 @@ module.exports = class GetSome extends Command {
       group: 'the-path',
       memberName: 'getsome',
       description: 'Get a random G E T A F T E R I T message to pump you up so you can get after it!',
-      examples: ['`.getsome`: GET AFTER IT']
+      examples: ['`!getsome`: GET AFTER IT']
     });
 
     this.quotesList = [

--- a/commands/the-path/remindme.js
+++ b/commands/the-path/remindme.js
@@ -8,9 +8,9 @@ module.exports = class RemindMe extends Command {
       group: 'the-path',
       memberName: 'remindme',
       description: 'Set a reminder interval. Meaningbot will DM you, reminding you to get after it!',
-      examples: ['`.remindme daily`: Gets a DM daily to remind you to get after it!',
-                 '`.remindme weekly`: Get a DM weekly to remind you to get after it!',
-                 '`.remindme never`: Stop getting DM reminders. But Meaningbot will still have your current commitments.'],
+      examples: ['`!remindme daily`: Gets a DM daily to remind you to get after it!',
+                 '`!remindme weekly`: Get a DM weekly to remind you to get after it!',
+                 '`!remindme never`: Stop getting DM reminders. But Meaningbot will still have your current commitments.'],
       args: [{
         key: 'frequency',
         prompt: 'How often do you want to be reminded?',

--- a/commands/the-path/update.js
+++ b/commands/the-path/update.js
@@ -8,7 +8,7 @@ module.exports = class Update extends Command {
       group: 'the-path',
       memberName: 'update',
       description: 'Update your commentmet logs',
-      examples: ['`.update Become the #1 lobster`: Commitment update from `Standup straight with shoulders back` to `Become the #1 lobster`'],
+      examples: ['`!update Become the #1 lobster`: Commitment update from\n"Standup straight with shoulders back"\nto\n"Become the #1 lobster"'],
       args: [{
         key: 'text',
         prompt: 'What is your updated commitment?',
@@ -45,6 +45,6 @@ module.exports = class Update extends Command {
 
     let res = await db.updateCommit(message.author.id, text, new Date());
     if(res === null) return await message.reply('There was an error trying to update the commitment. Let Alex or one of the bot masters know!');
-    return await message.reply(`${randQuote} \n Your commitment has been updated! Commitment changed from ${isThere.commit} to ${text}`);
+    return await message.reply(`${randQuote} \n Your commitment has been updated! Commitment changed from \n"${isThere.commit}"\nto\n"${text}"`);
   }
 };

--- a/commands/the-path/viewcommitment.js
+++ b/commands/the-path/viewcommitment.js
@@ -8,9 +8,9 @@ module.exports = class ViewCommitment extends Command{
       group: 'the-path',
       memberName: 'viewcommitment',
       description: 'Reads out your current commitments back to you.',
-      example: ['`.viewcommitment` Your current commitment is: "Do 100 push-ups"\nAnd you will get a DM reminder this often: never',
-                '`.viewcommitment` Your current commitment is: "Clean up your room"\nAnd you will get a DM reminder this often: weekly',
-                '`.viewcommitment` Your current commitment is: "Become #1 lobster"\nAnd you will get a DM reminder this often: daily']
+      example: ['`!viewcommitment` Your current commitment is: "Do 100 push-ups"\nAnd you will get a DM reminder this often: never',
+                '`!viewcommitment` Your current commitment is: "Clean up your room"\nAnd you will get a DM reminder this often: weekly',
+                '`!viewcommitment` Your current commitment is: "Become #1 lobster"\nAnd you will get a DM reminder this often: daily']
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const db = require('./db/db.js');
 const { checkInterval } = require('./helpers.js');
 
 const client = new CommandoClient({
-	commandPrefix: '.',
+	commandPrefix: '!',
 	owner: ['184136353812840449','294705970511085570','379336215205380106','456947461714345984']
 });
 

--- a/readme.md
+++ b/readme.md
@@ -9,11 +9,11 @@ The bot will take commands from #the-path channel. It will DM the user to remind
 ## Commands
 
 ```
-.commit - set a commitment or goal to get after it
-.remindme [daily/semiweekly/weekly/biweekly/monthly/never] - set the interval of how often the user is reminded to stay on the path
-.update - update the bot (and the community) on the current progress
-.getsome - Bot will post a random message from The ＰＡＴＨ ＧＡＮＧ
-.commands - get a list of commands sent to your DM
+!commit - set a commitment or goal to get after it
+!remindme [daily/semiweekly/weekly/biweekly/monthly/never] - set the interval of how often the user is reminded to stay on the path
+!update - update the bot (and the community) on the current progress
+!getsome - Bot will post a random message from The ＰＡＴＨ ＧＡＮＧ
+!commands - get a list of commands sent to your DM
 
 More to come(?)
 ```


### PR DESCRIPTION
Change the bot's command prefix from `.` to `!` because the community was getting confused by it. Also change the bot's reminder DM logic. Should now send out DMs when at or after the original message creation time, instead of only sending reminder DMs after the last DM time